### PR TITLE
properly mongoize arrays of keys

### DIFF
--- a/lib/mongoid/enum/enum_type.rb
+++ b/lib/mongoid/enum/enum_type.rb
@@ -19,6 +19,8 @@ module Mongoid
           # XXX Mongoid may try to mongoize multiple times so if key is a valid value
           # assume that it has already been converted to value.
           value = key
+        elseif key.is_a?(Array)
+          value = key.map { |k| mongoize(k) }
         else
           value = Enum::InvalidKey.new(key)
         end


### PR DESCRIPTION
This change is required for cases when key is an array ( like for Model.in(enum_key: ["key1","key2"]) )